### PR TITLE
feat: return event id of captured event

### DIFF
--- a/surveillance/sentry.go
+++ b/surveillance/sentry.go
@@ -100,7 +100,8 @@ func (wrapper *Sentry) Capture(err error, _panic bool) sentry.EventID {
 }
 
 // Handles an error by capturing it on Sentry and logging the same on STDOUT
-func (wrapper *Sentry) CaptureWithContext(c context.Context, err error, _panic bool) {
+func (wrapper *Sentry) CaptureWithContext(c context.Context, err error, _panic bool) sentry.EventID {
+	eventID := new(sentry.EventID)
 	if err != nil {
 		// Do not log to sentry if the error is ignorable.
 		// However, do log it to stdout
@@ -122,8 +123,8 @@ func (wrapper *Sentry) CaptureWithContext(c context.Context, err error, _panic b
 				})
 
 				// Capturing the error on Sentry
-				eventId := hub.CaptureException(err)
-				log.Errorf(err, "Error captured in sentry with the event ID `%s`", *eventId)
+				eventID = hub.CaptureException(err)
+				log.Errorf(err, "Error captured in sentry with the event ID `%s`", *eventID)
 			} else {
 				wrapper.Capture(err, _panic)
 			}
@@ -136,6 +137,8 @@ func (wrapper *Sentry) CaptureWithContext(c context.Context, err error, _panic b
 			panic(err)
 		}
 	}
+
+	return *eventID
 }
 
 // Wrapper over sentry-go/http#HandleFunc

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/Vernacular-ai/vcore/errors"
 	"github.com/Vernacular-ai/vcore/surveillance"
+	"github.com/getsentry/sentry-go"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -358,8 +359,8 @@ func CloseAnythingSafely(toClose interface{}) {
 }
 
 // Handles an error by capturing it on Sentry and logging the same on STDOUT
-func Capture(err error, _panic bool) {
-	surveillance.SentryClient.Capture(err, _panic)
+func Capture(err error, _panic bool) sentry.EventID {
+	return surveillance.SentryClient.Capture(err, _panic)
 }
 
 func StringifyToJson(i interface{}) (stringifiedJson string) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
@@ -361,6 +362,11 @@ func CloseAnythingSafely(toClose interface{}) {
 // Handles an error by capturing it on Sentry and logging the same on STDOUT
 func Capture(err error, _panic bool) sentry.EventID {
 	return surveillance.SentryClient.Capture(err, _panic)
+}
+
+// Handles an error by capturing it on Sentry and logging the same on STDOUT
+func CaptureWithContext(c context.Context, err error, _panic bool) sentry.EventID {
+	return surveillance.SentryClient.CaptureWithContext(c, err, _panic)
 }
 
 func StringifyToJson(i interface{}) (stringifiedJson string) {


### PR DESCRIPTION
We get an event id from sentry after getting captured \
This PR makes it available to use by returning it from the parent function