### PR TITLE
add: sample rate in sentry init

### DIFF
--- a/surveillance/sentry.go
+++ b/surveillance/sentry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/Vernacular-ai/vcore/errors"
 	"github.com/Vernacular-ai/vcore/log"
@@ -23,6 +24,9 @@ type Sentry struct {
 
 func InitSentry(release string) (client *Sentry) {
 	dsn := os.Getenv("SENTRY_DSN")
+
+	sampleRate, _ := strconv.ParseFloat(os.Getenv("SENTRY_SAMPLING"), 64)
+
 	if release == "" {
 		release = os.Getenv("SENTRY_RELEASE")
 	}
@@ -35,7 +39,8 @@ func InitSentry(release string) (client *Sentry) {
 
 			// Enable debugging to check connectivity
 			//Debug: true,
-			Release: release,
+			Release:    release,
+			SampleRate: sampleRate,
 
 			Environment: os.Getenv("ENVIRONMENT"),
 		}); err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -408,3 +408,11 @@ func ConvertInterfaceToString(val interface{}) (string, bool) {
 	stringValue, ok := val.(string)
 	return stringValue, ok
 }
+
+// GetEnv - Return the fallback env if not present
+func GetEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}


### PR DESCRIPTION
Add support for Sampling rate in Sentry. Sentry client will push logs to sentry server based on the sampling rate (1.0 for 100%, 0.5 for 50%).