### PR TITLE
fix: Nilpointer Dereference due to missing event ID

### DIFF
--- a/surveillance/sentry.go
+++ b/surveillance/sentry.go
@@ -140,7 +140,11 @@ func (wrapper *Sentry) CaptureWithContext(c context.Context, err error, _panic b
 
 				// Capturing the error on Sentry
 				eventID = hub.CaptureException(err)
-				log.Errorf(err, "Error captured in sentry with the event ID `%s`", *eventID)
+				if eventID != nil {
+					log.Errorf(err, "Error captured in sentry with the event ID `%s`", *eventID)
+				} else {
+					log.Error(err, "Error could not be captured in sentry due to nil event ID")
+				}
 			} else {
 				wrapper.Capture(err, _panic)
 			}


### PR DESCRIPTION
This fixes the edge case where an event ID is nil.

Stacktrace observed:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x9f71be]

goroutine 3354 [running]:
github.com/skit-ai/vcore/surveillance.(*Sentry).CaptureWithContext(0xc0007a2dd0, {0x19723d8?, 0xc00444db00?}, {0x1962700, 0xc002540060}, 0x0)
	/go/pkg/mod/github.com/skit-ai/vcore@v1.7.9/surveillance/sentry.go:143 +0x15e
/....func1(0xc001cbe930, 0xc00f96e138)
	/go/src/....go:394 +0x8ed
created by /... in goroutine 3394
	/go/src/....go:373 +0x285
```